### PR TITLE
Quick try at local dev durable objects

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "build-cf-types": "wrangler types --experimental-include-runtime",
     "dev": "waku dev",
+    "dev:do": "wrangler dev -c ./wrangler.dev-durable-objects.jsonc",
     "build": "waku build --with-cloudflare",
     "start": "wrangler dev"
   },

--- a/src/state.ts
+++ b/src/state.ts
@@ -34,3 +34,5 @@ export class MyDurableObject extends DurableObject {
     return result[0]?.value || 0;
   }
 }
+
+export default {};

--- a/wrangler.dev-durable-objects.jsonc
+++ b/wrangler.dev-durable-objects.jsonc
@@ -1,0 +1,7 @@
+{
+  "$schema": "./node_modules/wrangler/config-schema.json",
+  "name": "waku-with-durable-objects-dev-durable-objects-worker",
+  "compatibility_date": "2025-01-29",
+  "compatibility_flags": ["nodejs_compat"],
+  "main": "./src/state.ts"
+}

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -17,7 +17,8 @@
     "bindings": [
       {
         "name": "MY_DURABLE_OBJECT",
-        "class_name": "MyDurableObject"
+        "class_name": "MyDurableObject",
+        "script_name": "waku-with-durable-objects-dev-durable-objects-worker"
       }
     ]
   },


### PR DESCRIPTION
I found some docs here - https://developers.cloudflare.com/workers/wrangler/api/#supported-bindings

But when I run `bun run dev:do` and then launch `bun run dev`, I find that they still don't have that working with RPC. I think it only works with the older fetch() API for durable objects. Which is a pain. But might be ok to do it that way for now and then update to RPC when they add support?

I'm still going to look how into we can get them into the waku build to deploy to Cloudflare but I wanted to share what I found with the dev server.

I think this is the open issue to track https://github.com/cloudflare/workers-sdk/issues/7842

Here are related issues -
https://github.com/cloudflare/workers-sdk/issues/5918
https://github.com/cloudflare/workers-sdk/pull/7098
